### PR TITLE
ci: use semantic release config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,21 @@
-Changelog
-
-## [0.2.2](https://github.com/adobe/generator-tsx/compare/v0.2.1...v0.2.2) (2019-06-11)
-
-
-### Bug Fixes
-
-* remove extraneous graphql-tag dependency ([83d6ec1](https://github.com/adobe/generator-tsx/commit/83d6ec1))
-
-## [0.2.1](https://github.com/adobe/generator-tsx/compare/v0.2.0...v0.2.1) (2019-06-11)
-
-
-### Bug Fixes
-
-* create reducer for actions (fetch/set) ([f92c442](https://github.com/adobe/generator-tsx/commit/f92c442))
-
 # Changelog
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.2.2](https://github.com/adobe/generator-tsx/compare/v0.2.1...v0.2.2) (2019-06-11)
+
+### Bug Fixes
+
+- remove extraneous graphql-tag dependency
+  ([83d6ec1](https://github.com/adobe/generator-tsx/commit/83d6ec1))
+
+## [0.2.1](https://github.com/adobe/generator-tsx/compare/v0.2.0...v0.2.1) (2019-06-11)
+
+### Bug Fixes
+
+- create reducer for actions (fetch/set)
+  ([f92c442](https://github.com/adobe/generator-tsx/commit/f92c442))
 
 # [0.2.0](https://github.com/adobe/generator-tsx/compare/v0.1.6...v0.2.0) (2019-06-07)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,6 +451,20 @@
         }
       }
     },
+    "@jedmao/semantic-release-npm-github-config": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jedmao/semantic-release-npm-github-config/-/semantic-release-npm-github-config-1.0.2.tgz",
+      "integrity": "sha512-lDljWPsQAuWo3MS1OCq6rdBVV+i83vGb4ceVTRxLyhZCohp1z4MJdDnwQT9/O7zdx4BMcIsi+KlmCsgm47AT3Q==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/changelog": "^3.0.2",
+        "@semantic-release/commit-analyzer": "^6.1.0",
+        "@semantic-release/git": "^7.0.8",
+        "@semantic-release/github": "^5.2.10",
+        "@semantic-release/npm": "^5.1.7",
+        "@semantic-release/release-notes-generator": "^7.1.4"
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
-    "@semantic-release/changelog": "^3.0.2",
-    "@semantic-release/git": "^7.0.8",
+    "@jedmao/semantic-release-npm-github-config": "^1.0.2",
     "@types/fs-extra": "^7.0.0",
     "@types/jest": "^24.0.13",
     "@types/yeoman-assert": "^3.1.1",
@@ -176,33 +175,7 @@
   },
   "release": {
     "branch": "master",
-    "plugins": [
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/changelog",
-        {
-          "changelogTitle": "Changelog"
-        }
-      ],
-      [
-        "@semantic-release/npm",
-        {
-          "tarballDir": "dist"
-        }
-      ],
-      [
-        "@semantic-release/github",
-        {
-          "assets": "dist/*.tgz"
-        }
-      ],
-      [
-        "@semantic-release/git",
-        {
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-        }
-      ]
-    ]
+    "extends": "@jedmao/semantic-release-npm-github-config"
   },
   "repository": "https://github.com/adobe/generator-tsx.git",
   "license": "MIT"


### PR DESCRIPTION
## Description

Use [`@jedmao/semantic-release-npm-github-config`](https://www.npmjs.com/package/@jedmao/semantic-release-npm-github-config).

## Motivation and Context

Rather than specifying the exact same configuration for various npm packages that are associated with GitHub repositories, we can leverage semantic-release [shareable configurations](https://semantic-release.gitbook.io/semantic-release/usage/shareable-configurations) to store a common npm/GitHub config in one place.

## How Has This Been Tested?

Merging this PR and seeing a successful release is the test.
