### PR TITLE
feat: immutability-helper -> immer

### DIFF
--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -218,7 +218,7 @@ export = class AppGenerator extends Generator {
 			'@queso/kebab-case@^1',
 			'@reach/router@^1',
 			'full-icu@^1',
-			'immutability-helper@^3',
+			'immer@^4',
 			'ky@^0',
 			'ky-universal@^0',
 			'pathjoin@^0',

--- a/generators/app/templates/src/reducers/global/globalReducer.ts
+++ b/generators/app/templates/src/reducers/global/globalReducer.ts
@@ -3,11 +3,6 @@ import createReducer from 'utils/createReducer'
 
 const defaultState = {}
 
-export default createReducer('global', defaultState)(
-	(state, action: types.GlobalActions) => {
-		switch (action.type) {
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.GlobalActions>(
+	'global',
+)((/* draft, action */) => undefined)

--- a/generators/app/templates/src/utils/createReducer.test.ts
+++ b/generators/app/templates/src/utils/createReducer.test.ts
@@ -4,15 +4,15 @@ import createReducer from './createReducer'
 
 describe('createReducer', () => {
 	it('returns a function that updates state', () => {
-		const reducer = createReducer('test', { foo: 'old' })(
-			(state, action: AnyAction) => {
-				return action.type === 'UPDATE_FOO'
-					? { ...state, foo: 'new' }
-					: state
+		const reducer = createReducer<{ foo: string }, AnyAction>('test')(
+			(draft, action) => {
+				if (action.type === 'UPDATE_FOO') {
+					draft.foo = 'new'
+				}
 			},
 		)
 
-		const newState = reducer(void 0, { type: 'UPDATE_FOO' })
+		const newState = reducer({}, { type: 'UPDATE_FOO' })
 
 		expect(newState).toEqual({ foo: 'new' })
 	})

--- a/generators/app/templates/src/utils/createReducer.ts
+++ b/generators/app/templates/src/utils/createReducer.ts
@@ -1,16 +1,10 @@
-import { Reducer } from 'redux'
-import { DeepReadonly } from 'ts-essentials'
+import produce, { Draft } from 'immer'
 
 import RootActions from 'actions'
 
-export default function createReducer<T>(name: string, defaultState: T) {
-	return <A extends RootActions>(
-		callback: (state: DeepReadonly<T>, action: A) => DeepReadonly<T>,
-	) => {
-		const reducer: Reducer<DeepReadonly<T>, A> = (
-			previousState = defaultState as DeepReadonly<T>,
-			action: A,
-		) => callback(previousState, action)
+export default function createReducer<T, A extends RootActions>(name: string) {
+	return (recipe: (draft: Draft<Partial<T>>, action: A) => void) => {
+		const reducer = produce(recipe)
 		return Object.defineProperty(reducer, 'name', {
 			value: `${name}Reducer`,
 			configurable: true,

--- a/generators/reducer/expected/fetch/barBaz/barBazReducer.ts
+++ b/generators/reducer/expected/fetch/barBaz/barBazReducer.ts
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import { types } from 'actions/barBaz'
 import FakeModel from 'models/FakeModel'
 import createReducer from 'utils/createReducer'
@@ -14,23 +12,15 @@ const defaultState: BarBazState = {
 	loading: false,
 }
 
-export default createReducer('barBaz', defaultState)(
-	(state, action: types.BarBazActions) => {
-		switch (action.type) {
-			case types.FETCH_FAKE_MODEL_FAILURE:
-				return update(defaultState, {
-					errors: { $set: action.errors },
-				})
-			case types.FETCH_FAKE_MODEL_REQUEST:
-				return update(state, {
-					loading: { $set: true },
-				})
-			case types.FETCH_FAKE_MODEL_SUCCESS:
-				return update(defaultState, {
-					$merge: action.fakeModel,
-				})
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.BarBazActions>(
+	'barBaz',
+)((draft, action) => {
+	switch (action.type) {
+		case types.FETCH_FAKE_MODEL_FAILURE:
+			draft.errors = action.errors
+		case types.FETCH_FAKE_MODEL_REQUEST:
+			draft.loading = true
+		case types.FETCH_FAKE_MODEL_SUCCESS:
+			Object.assign(draft, action.fakeModel)
+	}
+})

--- a/generators/reducer/expected/set/barBaz/barBazReducer.ts
+++ b/generators/reducer/expected/set/barBaz/barBazReducer.ts
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import { types } from 'actions/barBaz'
 import FakeState from 'models/FakeState'
 import createReducer from 'utils/createReducer'
@@ -12,15 +10,11 @@ const defaultState: BarBazState = {
 	fakeState: {},
 }
 
-export default createReducer('barBaz', defaultState)(
-	(state, action: types.BarBazActions) => {
-		switch (action.type) {
-			case types.SET_FAKE_STATE:
-				return update(defaultState, {
-					fakeState: { $set: action.fakeState },
-				})
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.BarBazActions>(
+	'barBaz',
+)((draft, action) => {
+	switch (action.type) {
+		case types.SET_FAKE_STATE:
+			draft.fakeState = action.fakeState
+	}
+})

--- a/generators/reducer/templates/fetch/fooReducer.ts
+++ b/generators/reducer/templates/fetch/fooReducer.ts
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import { types } from 'actions/<%= name %>'
 import <%= sentenceCase(subject) %> from 'models/<%= sentenceCase(subject) %>'
 import createReducer from 'utils/createReducer'
@@ -14,23 +12,15 @@ const defaultState: <%= sentenceCase(name) %>State = {
 	loading: false,
 }
 
-export default createReducer('<%= name %>', defaultState)(
-	(state, action: types.<%= sentenceCase(name) %>Actions) => {
-		switch (action.type) {
-			case types.<%= snakeCase(actionName).toUpperCase() %>_FAILURE:
-				return update(defaultState, {
-					errors: { $set: action.errors },
-				})
-			case types.<%= snakeCase(actionName).toUpperCase() %>_REQUEST:
-				return update(state, {
-					loading: { $set: true },
-				})
-			case types.<%= snakeCase(actionName).toUpperCase() %>_SUCCESS:
-				return update(defaultState, {
-					$merge: action.<%= camelCase(subject) %>,
-				})
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.<%= sentenceCase(name) %>Actions>(
+	'<%= name %>',
+)((draft, action) => {
+	switch (action.type) {
+		case types.<%= snakeCase(actionName).toUpperCase() %>_FAILURE:
+			draft.errors = action.errors
+		case types.<%= snakeCase(actionName).toUpperCase() %>_REQUEST:
+			draft.loading = true
+		case types.<%= snakeCase(actionName).toUpperCase() %>_SUCCESS:
+			Object.assign(draft, action.<%= camelCase(subject) %>)
+	}
+})

--- a/generators/reducer/templates/set/fooReducer.ts
+++ b/generators/reducer/templates/set/fooReducer.ts
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import { types } from 'actions/<%= name %>'
 import <%= sentenceCase(subject) %> from 'models/<%= sentenceCase(subject) %>'
 import createReducer from 'utils/createReducer'
@@ -12,15 +10,11 @@ const defaultState: <%= sentenceCase(name) %>State = {
 	<%= subject %>: {},
 }
 
-export default createReducer('<%= name %>', defaultState)(
-	(state, action: types.<%= sentenceCase(name) %>Actions) => {
-		switch (action.type) {
-			case types.<%= snakeCase(actionName).toUpperCase() %>:
-				return update(defaultState, {
-					<%= subject %>: { $set: action.<%= subject %> },
-				})
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.<%= sentenceCase(name) %>Actions>(
+	'<%= name %>',
+)((draft, action) => {
+	switch (action.type) {
+		case types.<%= snakeCase(actionName).toUpperCase() %>:
+			draft.<%= subject %> = action.<%= subject %>
+	}
+})

--- a/generators/reducer/templates/sync/fooReducer.ts
+++ b/generators/reducer/templates/sync/fooReducer.ts
@@ -1,5 +1,3 @@
-import update from 'immutability-helper'
-
 import { types } from 'actions/<%= name %>'
 import <%= sentenceCase(subject) %> from 'models/<%= sentenceCase(subject) %>'
 import createReducer from 'utils/createReducer'
@@ -12,15 +10,11 @@ const defaultState: <%= sentenceCase(name) %>State = {
 	<%= subject %>: {},
 }
 
-export default createReducer('<%= name %>', defaultState)(
-	(state, action: types.<%= sentenceCase(name) %>Actions) => {
-		switch (action.type) {
-			case types.<%= snakeCase(actionName).toUpperCase() %>:
-				return update(defaultState, {
-					<%= subject %>: { $set: action.<%= subject %> },
-				})
-			default:
-				return state
-		}
-	},
-)
+export default createReducer<typeof defaultState, types.<%= sentenceCase(name) %>Actions>(
+	'<%= name %>',
+)((draft, action) => {
+	switch (action.type) {
+		case types.<%= snakeCase(actionName).toUpperCase() %>:
+			draft.<%= subject %> = action.<%= subject %>
+	}
+})


### PR DESCRIPTION
Use [Immer](https://immerjs.github.io/immer/docs/introduction) instead of [`immutability-helper`](https://github.com/kolodny/immutability-helper).
- Requires less learning curve.
- Better TypeScript support.
- About the same bundle size.